### PR TITLE
[Feature] Create interest point registry

### DIFF
--- a/polyorbite-rover-control-portal/package-lock.json
+++ b/polyorbite-rover-control-portal/package-lock.json
@@ -25,6 +25,7 @@
         "roslib": "^1.1.0",
         "rxjs": "~6.6.0",
         "tslib": "^2.0.0",
+        "uuid": "^8.3.2",
         "zone.js": "~0.11.3"
       },
       "devDependencies": {
@@ -15629,7 +15630,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -30523,8 +30523,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-name": {
       "version": "3.0.0",

--- a/polyorbite-rover-control-portal/package.json
+++ b/polyorbite-rover-control-portal/package.json
@@ -29,6 +29,7 @@
     "roslib": "^1.1.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
+    "uuid": "^8.3.2",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/polyorbite-rover-control-portal/src/app/app.component.html
+++ b/polyorbite-rover-control-portal/src/app/app.component.html
@@ -11,5 +11,8 @@
                [zoom]="14">
       </app-map>
     </mat-card>
+    <mat-card interest-points>
+      <app-interest-points></app-interest-points>
+    </mat-card>
   </main>
 </div>

--- a/polyorbite-rover-control-portal/src/app/app.module.ts
+++ b/polyorbite-rover-control-portal/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MapComponent } from './map/map.component';
 import { InterestPointsComponent } from './interest-point/component/list/interest-points.component';
 import { PhotographInterestPointDetailsComponent } from './interest-point/component/details/photograph/photograph-interest-point-details.component';
 import { InterestPointDetailsComponent } from './interest-point/component/details/base/interest-point-details.component';
+import { EditableTextComponent } from './editable-text/editable-text.component';
 
 @NgModule({
   declarations: [
@@ -23,6 +24,7 @@ import { InterestPointDetailsComponent } from './interest-point/component/detail
     InterestPointsComponent,
     PhotographInterestPointDetailsComponent,
     InterestPointDetailsComponent,
+    EditableTextComponent,
   ],
   imports: [
     BrowserModule,

--- a/polyorbite-rover-control-portal/src/app/app.module.ts
+++ b/polyorbite-rover-control-portal/src/app/app.module.ts
@@ -9,6 +9,9 @@ import { VideoStreamSwitchComponent } from './video-stream-switch/video-stream-s
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { RoverStateComponent } from './rover-state/rover-state.component';
 import { MapComponent } from './map/map.component';
+import { InterestPointsComponent } from './interest-point/component/list/interest-points.component';
+import { PhotographInterestPointDetailsComponent } from './interest-point/component/details/photograph/photograph-interest-point-details.component';
+import { InterestPointDetailsComponent } from './interest-point/component/details/base/interest-point-details.component';
 
 @NgModule({
   declarations: [
@@ -17,6 +20,9 @@ import { MapComponent } from './map/map.component';
     VideoStreamSwitchComponent,
     RoverStateComponent,
     MapComponent,
+    InterestPointsComponent,
+    PhotographInterestPointDetailsComponent,
+    InterestPointDetailsComponent,
   ],
   imports: [
     BrowserModule,

--- a/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.html
+++ b/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.html
@@ -1,0 +1,6 @@
+<input *ngIf="isEditing"
+         type="text"
+         #editor
+         [value]="text"
+         (keyup.enter)="updateText()">
+<label *ngIf="!isEditing" (dblclick)="isEditing = true">{{ text }}</label>

--- a/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditableTextComponent } from './editable-text.component';
+
+describe('EditableTextComponent', () => {
+  let component: EditableTextComponent;
+  let fixture: ComponentFixture<EditableTextComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EditableTextComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditableTextComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.ts
+++ b/polyorbite-rover-control-portal/src/app/editable-text/editable-text.component.ts
@@ -1,0 +1,24 @@
+import { Component, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, ViewChild } from '@angular/core';
+
+@Component({
+  selector: 'editable-text',
+  templateUrl: './editable-text.component.html',
+  styleUrls: ['./editable-text.component.sass']
+})
+export class EditableTextComponent {
+  @Input('text') text: string;
+  @Output('textChange') textChange: EventEmitter<string> = new EventEmitter<string>();
+
+  @ViewChild('editor') editor: ElementRef<HTMLInputElement>;
+
+  isEditing: boolean = false;
+
+  updateText(): void {
+    const newText = this.editor.nativeElement.value;
+
+    this.text = newText;
+    this.textChange.emit(newText);
+
+    this.isEditing = false;
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/details/base/interest-point-details.component.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/details/base/interest-point-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InterestPointDetailsComponent } from './interest-point-details.component';
+
+describe('InterestPointDetailsComponent', () => {
+  let component: InterestPointDetailsComponent;
+  let fixture: ComponentFixture<InterestPointDetailsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InterestPointDetailsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InterestPointDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/details/base/interest-point-details.component.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/details/base/interest-point-details.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { InterestPoint } from 'src/app/interest-point/interest-point';
+
+@Component({
+  selector: 'app-interest-point-details',
+  template: '',
+})
+export class InterestPointDetailsComponent {
+  @Input('interest-point') interestPoint: InterestPoint;
+
+  constructor() { }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.html
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.html
@@ -1,0 +1,1 @@
+<img width="256" [src]="photographBase64">

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PhotographInterestPointDetailsComponent } from './photograph-interest-point-details.component';
+
+describe('PhotographInterestPointDetailsComponent', () => {
+  let component: PhotographInterestPointDetailsComponent;
+  let fixture: ComponentFixture<PhotographInterestPointDetailsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PhotographInterestPointDetailsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PhotographInterestPointDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/details/photograph/photograph-interest-point-details.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { InterestPoint } from 'src/app/interest-point/interest-point';
+import { PhotographInterestPointModel } from 'src/app/interest-point/model/photograph-interest-point.model';
+import { PhotographInterestPoint } from 'src/app/interest-point/type/photograph-interest-point';
+import { InterestPointDetailsComponent } from '../base/interest-point-details.component';
+
+@Component({
+  selector: 'app-photograph-interest-point-details',
+  templateUrl: './photograph-interest-point-details.component.html',
+  styleUrls: ['./photograph-interest-point-details.component.sass']
+})
+export class PhotographInterestPointDetailsComponent extends InterestPointDetailsComponent {
+
+  get photographBase64(): string {
+    const header = 'data:image/png;base64';
+    const data = (this.interestPoint as PhotographInterestPoint).model.imageBase64;
+    return `${header},${data}`;
+  }
+
+  constructor() {
+    super();
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.html
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.html
@@ -5,9 +5,10 @@
     <mat-list>
       <mat-list-item *ngFor="let interestPoint of interestPoints.entries">
         <button mat-stroked-button
-                (click)="selectedId = interestPoint.uuid"
+                (click)="select(interestPoint.uuid)"
                 [class.selected]="selectedId === interestPoint.uuid">
-          {{ interestPoint.name }}
+          <editable-text #interestPointNameEditors
+                         [(text)]="interestPoint.name"></editable-text>
         </button>
       </mat-list-item>
     </mat-list>
@@ -21,5 +22,4 @@
       </app-photograph-interest-point-details>
     </div>
   </div>
-
 </mat-drawer-container>

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.html
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.html
@@ -1,0 +1,25 @@
+<h3>Interest points</h3>
+
+<mat-drawer-container autosize class="container">
+  <mat-drawer #drawer mode="side" opened="true" disableClose="true" class="list">
+    <mat-list>
+      <mat-list-item *ngFor="let interestPoint of interestPoints.entries">
+        <button mat-stroked-button
+                (click)="selectedId = interestPoint.uuid"
+                [class.selected]="selectedId === interestPoint.uuid">
+          {{ interestPoint.name }}
+        </button>
+      </mat-list-item>
+    </mat-list>
+  </mat-drawer>
+
+  <div class="details">
+    <div *ngFor="let interestPoint of interestPoints.entries">
+      <app-photograph-interest-point-details
+            [interest-point]="interestPoint"
+            *ngIf="selectedId === interestPoint.uuid">
+      </app-photograph-interest-point-details>
+    </div>
+  </div>
+
+</mat-drawer-container>

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.sass
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.sass
@@ -1,0 +1,20 @@
+*
+  color: #FFF
+
+.container
+  width: 500px
+  height: 300px
+  background: #00000000
+
+.details
+  display: flex
+  height: 100%
+  align-items: center
+  justify-content: center
+  background: #00000000
+
+.list
+  background: #00000000
+
+button.selected
+  background-color: #aaaaaa7e

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InterestPointsComponent } from './interest-points.component';
+
+describe('InterestPointsComponent', () => {
+  let component: InterestPointsComponent;
+  let fixture: ComponentFixture<InterestPointsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InterestPointsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InterestPointsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { InterestPointService } from '../../service/interest-point.service';
+
+@Component({
+  selector: 'app-interest-points',
+  templateUrl: './interest-points.component.html',
+  styleUrls: ['./interest-points.component.sass']
+})
+export class InterestPointsComponent {
+  selectedId: string;
+
+  constructor(public interestPoints: InterestPointService) {
+    if(this.interestPoints.entries.length > 0) {
+      this.selectedId = this.interestPoints.entries[0].uuid;
+    }
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/component/list/interest-points.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, EventEmitter, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { EditableTextComponent } from 'src/app/editable-text/editable-text.component';
 import { InterestPointService } from '../../service/interest-point.service';
 
 @Component({
@@ -8,6 +9,21 @@ import { InterestPointService } from '../../service/interest-point.service';
 })
 export class InterestPointsComponent {
   selectedId: string;
+
+  @ViewChildren('interestPointNameEditors') interestPointNameEditors: QueryList<EditableTextComponent>;
+
+  select(uuid: string): void {
+    if(uuid !== this.selectedId) {
+      this.stopEditing();
+      this.selectedId = uuid;
+    }
+  }
+
+  stopEditing(): void {
+    this.interestPointNameEditors.forEach(
+      editor => editor.isEditing = false
+    );
+  }
 
   constructor(public interestPoints: InterestPointService) {
     if(this.interestPoints.entries.length > 0) {

--- a/polyorbite-rover-control-portal/src/app/interest-point/interest-point.model.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/interest-point.model.ts
@@ -1,0 +1,1 @@
+export class InterestPointModel {}

--- a/polyorbite-rover-control-portal/src/app/interest-point/interest-point.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/interest-point.ts
@@ -2,7 +2,8 @@ import { InterestPointModel } from "./interest-point.model";
 import { v4 as makeUuid } from 'uuid';
 
 export abstract class InterestPoint {
-  abstract get name(): string;
+  name: string;
+
   abstract get model(): InterestPointModel;
 
   get uuid(): string {

--- a/polyorbite-rover-control-portal/src/app/interest-point/interest-point.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/interest-point.ts
@@ -1,0 +1,23 @@
+import { InterestPointModel } from "./interest-point.model";
+import { v4 as makeUuid } from 'uuid';
+
+export abstract class InterestPoint {
+  abstract get name(): string;
+  abstract get model(): InterestPointModel;
+
+  get uuid(): string {
+    return this.mUuid;
+  }
+
+  get creationTimestamp(): Date {
+    return this.mCreationTimestamp;
+  }
+
+  private mUuid: string;
+  private mCreationTimestamp: Date;
+
+  constructor() {
+    this.mUuid = makeUuid();
+    this.mCreationTimestamp = new Date();
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/model/photograph-interest-point.model.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/model/photograph-interest-point.model.ts
@@ -1,0 +1,7 @@
+import { InterestPointModel } from "../interest-point.model";
+
+export class PhotographInterestPointModel extends InterestPointModel {
+  constructor(public imageBase64: string) {
+    super();
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/service/interest-point.service.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/service/interest-point.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { InterestPointService } from './interest-point.service';
+
+describe('InterestPointService', () => {
+  let service: InterestPointService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(InterestPointService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/interest-point/service/interest-point.service.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/service/interest-point.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { InterestPoint } from '../interest-point';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class InterestPointService {
+  add(interestPoint: InterestPoint): void {
+    this.interestPoints.push(interestPoint);
+  }
+
+  clear(): void {
+    this.interestPoints = [];
+  }
+
+  get entries(): Array<InterestPoint> {
+    return this.interestPoints;
+  }
+
+  private interestPoints: Array<InterestPoint> = [];
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/type/photograph-interest-point.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/type/photograph-interest-point.ts
@@ -1,0 +1,24 @@
+import { InterestPoint } from "../interest-point";
+import { PhotographInterestPointModel } from "../model/photograph-interest-point.model";
+
+export class PhotographInterestPoint extends InterestPoint {
+  get name(): string {
+    return this.mName;
+  }
+
+  get model(): PhotographInterestPointModel {
+    return new PhotographInterestPointModel(this.imageBase64);
+  }
+
+  private mName: string;
+
+  private initializeName(): void {
+    const creationTime = this.creationTimestamp.toLocaleTimeString();
+    this.mName = `Photograph - ${creationTime}`;
+  }
+
+  constructor(private imageBase64: string) {
+    super();
+    this.initializeName();
+  }
+}

--- a/polyorbite-rover-control-portal/src/app/interest-point/type/photograph-interest-point.ts
+++ b/polyorbite-rover-control-portal/src/app/interest-point/type/photograph-interest-point.ts
@@ -2,23 +2,15 @@ import { InterestPoint } from "../interest-point";
 import { PhotographInterestPointModel } from "../model/photograph-interest-point.model";
 
 export class PhotographInterestPoint extends InterestPoint {
-  get name(): string {
-    return this.mName;
-  }
 
   get model(): PhotographInterestPointModel {
     return new PhotographInterestPointModel(this.imageBase64);
   }
 
-  private mName: string;
-
-  private initializeName(): void {
-    const creationTime = this.creationTimestamp.toLocaleTimeString();
-    this.mName = `Photograph - ${creationTime}`;
-  }
-
   constructor(private imageBase64: string) {
     super();
-    this.initializeName();
+
+    const creationTime = this.creationTimestamp.toLocaleTimeString();
+    this.name = `Photograph - ${creationTime}`;
   }
 }

--- a/polyorbite-rover-control-portal/src/app/map/map.component.ts
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.ts
@@ -88,10 +88,6 @@ export class MapComponent implements AfterViewInit {
     if(!this.map) this.zone.runOutsideAngular(() => this.initializeMap());
 
     setTimeout(() => {
-      console.log(this.container.nativeElement.clientWidth);
-      console.log(this.container.nativeElement.clientHeight);
-      console.log(this.width);
-      console.log(this.height);
       this.containerWidth = this.container.nativeElement.clientWidth;
       this.containerHeight = this.container.nativeElement.clientHeight;
     }, 1000);

--- a/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
+++ b/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
@@ -1,4 +1,11 @@
-<div #container>
-  <canvas #frame [width]="frameWidth" [height]="frameHeight"></canvas>
-  <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
+<div #container class="layout-container">
+  <div>
+    <canvas #frame [width]="frameWidth" [height]="frameHeight"></canvas>
+    <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
+  </div>
+  <div class="overlay">
+    <button mat-icon-button color="primary" (click)="takePicture()">
+      <mat-icon>photo_camera</mat-icon>
+    </button>
+  </div>
 </div>

--- a/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.ts
+++ b/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.ts
@@ -1,5 +1,7 @@
 import { AfterViewInit, Component, ElementRef, HostListener, Input, OnInit, ViewChild } from '@angular/core';
 import { Topic } from 'roslib';
+import { InterestPointService } from '../interest-point/service/interest-point.service';
+import { PhotographInterestPoint } from '../interest-point/type/photograph-interest-point';
 import { ROSService } from '../ROS/ros.service';
 
 @Component({
@@ -14,6 +16,8 @@ export class VideoStreamComponent implements AfterViewInit {
   private originalFrameHeight: number;
   private lastContainerWidth: number;
   private lastContainerHeight: number;
+
+  private lastFrameBase64: string;
 
   private firstFrameReceived: boolean;
 
@@ -56,6 +60,12 @@ export class VideoStreamComponent implements AfterViewInit {
     return this.m_cameraTopic === undefined || !this.firstFrameReceived;
   }
 
+  takePicture(): void {
+    this.interestPoints.add(
+      new PhotographInterestPoint(this.lastFrameBase64)
+    );
+  }
+
   private updateTopic(name: string): void {
     this.firstFrameReceived = false;
     this.m_cameraTopic?.unsubscribe();
@@ -65,6 +75,7 @@ export class VideoStreamComponent implements AfterViewInit {
 
   private refreshImage(imageBase64: string) {
     this.firstFrameReceived = true;
+    this.lastFrameBase64 = imageBase64;
 
     const canvasIsReady = this.frame != undefined;
 
@@ -89,5 +100,8 @@ export class VideoStreamComponent implements AfterViewInit {
     });
   }
 
-  constructor(private ros: ROSService) {}
+  constructor(
+    private ros: ROSService,
+    private interestPoints: InterestPointService
+  ) {}
 }

--- a/polyorbite-rover-control-portal/src/styles.sass
+++ b/polyorbite-rover-control-portal/src/styles.sass
@@ -21,3 +21,11 @@ body:after
 .center
   margin: auto
   text-align: center
+
+.overlay-container
+  position: relative
+
+.overlay
+  position: absolute
+  top: 0
+  right: 0


### PR DESCRIPTION
When at the competition, there will be things that we will want to save for later (i.e. for the soil report).

This PR adds interest points ; ex. photographs or sampling locations.

An interest point service has been added, you can register interest points in it.

An interest point list component has been added to the dashboard. It lists all interest points that have been created.
For now, the only type of interest points that exists is: photograph.

A camera icon overlay has been added to the video stream component, it creates a photograph interest point.

The interest point names can be edited from the dashboard.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/5231337/121786329-3120ea00-cb8d-11eb-9a57-bb2f036edce6.png)
