### PR TITLE
[Feature] Display GPS information

### DIFF
--- a/polyorbite-rover-control-portal/src/app/ROS/ros.service.ts
+++ b/polyorbite-rover-control-portal/src/app/ROS/ros.service.ts
@@ -8,7 +8,7 @@ export class ROSService {
   private ros: Ros;
 
   constructor() {
-    this.ros = new Ros({url: 'ws://192.168.3.11:9090'});
+    this.ros = new Ros({url: 'ws://jxnx:9090'});
 
     this.ros.on('error', () => {
       console.error('Could not connect to ROS');

--- a/polyorbite-rover-control-portal/src/app/app.component.html
+++ b/polyorbite-rover-control-portal/src/app/app.component.html
@@ -7,12 +7,14 @@
       <app-rover-state></app-rover-state>
     </mat-card>
     <mat-card map>
-      <!--<app-map [center]="[-12531000,6708172]"
-               [zoom]="14">
-      </app-map>-->
+      <app-map [zoom]="16">
+      </app-map>
     </mat-card>
     <mat-card interest-points>
       <app-interest-points></app-interest-points>
+    </mat-card>
+    <mat-card>
+      <app-gps-data-visualizer></app-gps-data-visualizer>
     </mat-card>
   </main>
 </div>

--- a/polyorbite-rover-control-portal/src/app/app.component.html
+++ b/polyorbite-rover-control-portal/src/app/app.component.html
@@ -7,7 +7,7 @@
       <app-rover-state></app-rover-state>
     </mat-card>
     <mat-card map>
-      <app-map [zoom]="16">
+      <app-map [zoom]="17">
       </app-map>
     </mat-card>
     <mat-card interest-points>

--- a/polyorbite-rover-control-portal/src/app/app.component.ts
+++ b/polyorbite-rover-control-portal/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { GamepadService } from './gamepad/gamepad.service';
+import { GpsService } from './gps/service/gps.service';
 import { KeyboardService } from './keyboard/keyboard.service';
 
 @Component({
@@ -8,5 +9,9 @@ import { KeyboardService } from './keyboard/keyboard.service';
   styleUrls: ['./app.component.sass']
 })
 export class AppComponent {
-  constructor(gamepad: GamepadService, keyboard: KeyboardService) {}
+  constructor(
+    gamepad: GamepadService,
+    keyboard: KeyboardService,
+    public gps: GpsService
+  ) {}
 }

--- a/polyorbite-rover-control-portal/src/app/app.module.ts
+++ b/polyorbite-rover-control-portal/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { InterestPointsComponent } from './interest-point/component/list/interes
 import { PhotographInterestPointDetailsComponent } from './interest-point/component/details/photograph/photograph-interest-point-details.component';
 import { InterestPointDetailsComponent } from './interest-point/component/details/base/interest-point-details.component';
 import { EditableTextComponent } from './editable-text/editable-text.component';
+import { GpsDataVisualizerComponent } from './gps/gps-data-visualizer/gps-data-visualizer.component';
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { EditableTextComponent } from './editable-text/editable-text.component';
     PhotographInterestPointDetailsComponent,
     InterestPointDetailsComponent,
     EditableTextComponent,
+    GpsDataVisualizerComponent,
   ],
   imports: [
     BrowserModule,

--- a/polyorbite-rover-control-portal/src/app/gps/data/wgs84-coordinates.ts
+++ b/polyorbite-rover-control-portal/src/app/gps/data/wgs84-coordinates.ts
@@ -1,0 +1,5 @@
+
+export type WGS84Coordinates = {
+    latitude: number;
+    longitude: number;
+};

--- a/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.html
+++ b/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.html
@@ -1,0 +1,1 @@
+<p>Current GPS coordinates: {{ gps.currentCoordinates.latitude }}, {{ gps.currentCoordinates.longitude }}</p>

--- a/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.sass
+++ b/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.sass
@@ -1,0 +1,2 @@
+*
+  color: white

--- a/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GpsDataVisualizerComponent } from './gps-data-visualizer.component';
+
+describe('GpsDataVisualizerComponent', () => {
+  let component: GpsDataVisualizerComponent;
+  let fixture: ComponentFixture<GpsDataVisualizerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ GpsDataVisualizerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GpsDataVisualizerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.ts
+++ b/polyorbite-rover-control-portal/src/app/gps/gps-data-visualizer/gps-data-visualizer.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+import { GpsService } from '../service/gps.service';
+
+@Component({
+  selector: 'app-gps-data-visualizer',
+  templateUrl: './gps-data-visualizer.component.html',
+  styleUrls: ['./gps-data-visualizer.component.sass']
+})
+export class GpsDataVisualizerComponent {
+
+  constructor(public gps: GpsService) { }
+}

--- a/polyorbite-rover-control-portal/src/app/gps/service/gps.service.spec.ts
+++ b/polyorbite-rover-control-portal/src/app/gps/service/gps.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GpsService } from './gps.service';
+
+describe('GpsService', () => {
+  let service: GpsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GpsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/polyorbite-rover-control-portal/src/app/gps/service/gps.service.ts
+++ b/polyorbite-rover-control-portal/src/app/gps/service/gps.service.ts
@@ -1,0 +1,27 @@
+import { EventEmitter, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ROSService } from 'src/app/ROS/ros.service';
+import { WGS84Coordinates } from '../data/wgs84-coordinates';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GpsService {
+  private readonly TOPIC_NAME = '/gps/fix';
+  private readonly MESSAGE_TYPE = 'sensor_msgs/NavSatFix';
+
+  constructor(private ros: ROSService) {
+    this.currentCoordinates = { latitude: 0, longitude: 0 };
+    let topic = ros.getTopic(this.TOPIC_NAME, this.MESSAGE_TYPE);
+    topic.subscribe((message: WGS84Coordinates) => {
+      this.currentCoordinates = {
+        latitude: message.latitude,
+        longitude: message.longitude
+      };
+      this.onFixUpdated.emit(this.currentCoordinates);
+    });
+  }
+
+  public currentCoordinates: WGS84Coordinates;
+  public onFixUpdated: EventEmitter<WGS84Coordinates> = new EventEmitter();
+}

--- a/polyorbite-rover-control-portal/src/app/map/map.component.html
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.html
@@ -4,4 +4,7 @@
        [style.width.px]="width"
        [style.height.px]="height">
   </div>
+  <mat-slide-toggle [checked]="autoCenter" (change)="autoCenter = $event.checked">
+      Auto center
+  </mat-slide-toggle>
 </div>

--- a/polyorbite-rover-control-portal/src/app/map/map.component.sass
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.sass
@@ -1,3 +1,6 @@
+*
+  color: white
+
 .map-container
   width: inherit
   height: inherit

--- a/polyorbite-rover-control-portal/src/app/map/map.component.ts
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.ts
@@ -21,9 +21,10 @@ const proj4 = (proj4Import as any).default;
   styleUrls: ['./map.component.sass']
 })
 export class MapComponent implements AfterViewInit {
-  private readonly PROJECTION_NAME = "EPSG:3857";
+  private readonly PROJECTION_NAME = "EPSG:4326"; // "EPSG:3857";
   private readonly PROJECTION_DEFINITION_ARGS =
-    "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs";
+    "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
+    //"+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs";
   private readonly PROJECTION_EXTENT: Extent = [
     -20026376.39,
     -20048966.10,
@@ -66,12 +67,11 @@ export class MapComponent implements AfterViewInit {
     proj4.defs(this.PROJECTION_NAME, this.PROJECTION_DEFINITION_ARGS);
     register(proj4);
     this.projection = GetProjection(this.PROJECTION_NAME);
-    this.projection.setExtent(this.PROJECTION_EXTENT);
 
     this.view = new View({
       center: this.center,
       zoom: this.zoom,
-      projection: 'EPSG:4326'
+      projection: this.projection
     });
 
     this.map = new Map({

--- a/polyorbite-rover-control-portal/src/app/map/map.component.ts
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.ts
@@ -17,6 +17,8 @@ import Style from 'ol/style/Style';
 import Icon from 'ol/style/Icon';
 import IconAnchorUnits from 'ol/style/IconAnchorUnits';
 import XYZ from 'ol/source/XYZ';
+import Point from 'ol/geom/Point';
+import { WGS84Coordinates } from '../gps/data/wgs84-coordinates';
 
 const proj4 = (proj4Import as any).default;
 
@@ -97,6 +99,23 @@ export class MapComponent implements AfterViewInit {
         new ScaleLine({})
       ])
     });
+    this.makeRoverMarker({ latitude: 0, longitude: 0});
+
+    this.view.centerOn([0, 0], toSize(this.zoom), [0, 0]);
+  }
+
+  private makeRoverMarker(coordinates: WGS84Coordinates) {
+    let roverSource = new VectorSource({});
+    let roverLayer = new VectorLayer({
+      source: roverSource
+    });
+    this.map.addLayer(roverLayer);
+    
+    let roverMarker = new Feature({
+      geometry: new Point([coordinates.longitude, coordinates.latitude])
+    });
+
+    roverSource.addFeature(roverMarker);
   }
 
   ngAfterViewInit(): void {
@@ -106,6 +125,7 @@ export class MapComponent implements AfterViewInit {
       if(this.autoCenter) {
         this.center = [coordinates.longitude, coordinates.latitude];
         this.view.centerOn(this.center, toSize(this.zoom), [0, 0]);
+        this.makeRoverMarker(coordinates);
       }
     });
 

--- a/polyorbite-rover-control-portal/src/app/map/map.component.ts
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.ts
@@ -12,6 +12,11 @@ import TileLayer from 'ol/layer/Tile';
 import OSM, {ATTRIBUTION} from 'ol/source/OSM';
 import { GpsService } from '../gps/service/gps.service';
 import { toSize } from 'ol/size';
+import VectorSource from 'ol/source/Vector';
+import Style from 'ol/style/Style';
+import Icon from 'ol/style/Icon';
+import IconAnchorUnits from 'ol/style/IconAnchorUnits';
+import XYZ from 'ol/source/XYZ';
 
 const proj4 = (proj4Import as any).default;
 
@@ -78,6 +83,12 @@ export class MapComponent implements AfterViewInit {
       layers: [
         new TileLayer({
           source: new OSM({})
+        }),
+        new TileLayer({
+          source: new XYZ({
+            url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            maxZoom: 19
+          })
         })
       ],
       target: 'map',

--- a/polyorbite-rover-control-portal/src/app/map/map.component.ts
+++ b/polyorbite-rover-control-portal/src/app/map/map.component.ts
@@ -44,6 +44,8 @@ export class MapComponent implements AfterViewInit {
   private containerWidth: number;
   private containerHeight: number;
 
+  private roverPositionMarker: Feature;
+
   autoCenter: boolean = true;
 
   view: View;
@@ -111,11 +113,11 @@ export class MapComponent implements AfterViewInit {
     });
     this.map.addLayer(roverLayer);
     
-    let roverMarker = new Feature({
+    this.roverPositionMarker = new Feature({
       geometry: new Point([coordinates.longitude, coordinates.latitude])
     });
 
-    roverSource.addFeature(roverMarker);
+    roverSource.addFeature(this.roverPositionMarker);
   }
 
   ngAfterViewInit(): void {
@@ -125,7 +127,7 @@ export class MapComponent implements AfterViewInit {
       if(this.autoCenter) {
         this.center = [coordinates.longitude, coordinates.latitude];
         this.view.centerOn(this.center, toSize(this.zoom), [0, 0]);
-        this.makeRoverMarker(coordinates);
+        this.roverPositionMarker.setGeometry(new Point([coordinates.longitude, coordinates.latitude]));
       }
     });
 

--- a/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
+++ b/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
@@ -1,6 +1,6 @@
 <div #container class="layout-container">
   <div>
-    <img #frame [src]="videoUrl" [width]="frameWidth">
+    <!--<img #frame [src]="videoUrl" [width]="frameWidth">-->
     <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
   </div>
   <div class="overlay">

--- a/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
+++ b/polyorbite-rover-control-portal/src/app/video-stream/video-stream.component.html
@@ -1,6 +1,6 @@
 <div #container class="layout-container">
   <div>
-    <!--<img #frame [src]="videoUrl" [width]="frameWidth">-->
+    <img #frame [src]="videoUrl" [width]="frameWidth">
     <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
   </div>
   <div class="overlay">


### PR DESCRIPTION
GPS coordinates are displayed in text form and in the form of a marker on the map.
The position is updated automatically when the GPS publishes a new fix to its topic.

The view frame of the map is also updated automatically to always center on the rover's position.
You can disable this feature using a toggle switch.

![image](https://user-images.githubusercontent.com/5231337/128922464-c7ca5b17-c5f7-4e44-8514-fbf3f815594a.png)
